### PR TITLE
Fix throughput to latency

### DIFF
--- a/bloom-inference-scripts/bloom-accelerate-inference.py
+++ b/bloom-inference-scripts/bloom-accelerate-inference.py
@@ -225,11 +225,11 @@ if args.benchmark:
         generated = generate()
         total_new_tokens_generated += sum(new_tokens for _, _, new_tokens in generated)
     torch.cuda.synchronize()
-    througput = (time.time() - t0) / (total_new_tokens_generated)
+    latency = (time.time() - t0) / (total_new_tokens_generated)
     print_rank0(
         f"""
 *** Performance stats:
-Throughput per token including tokenize: {througput*1000:.2f} msecs
+Latency per token including tokenize: {latency*1000:.2f} msecs
 Start to ready to generate: {t_ready - t_start:.3f} secs
 Tokenize and generate {total_new_tokens_generated} (bs={args.batch_size}) tokens: {t_generate_span:.3f} secs
 Start to finish: {t_ready - t_start + t_generate_span:.3f} secs


### PR DESCRIPTION
Reported result to be latency other than throughput

100s to generate 10 tokens,  (100s / 10) 10s per token, (10 / 100s) 0.1 token/s.