### PR TITLE
Reflect model_class option to server deployment (Fixes #33)

### DIFF
--- a/inference_server/README.md
+++ b/inference_server/README.md
@@ -35,12 +35,12 @@ Example: generate_kwargs =
 
 1. using HF accelerate
 ```shell
-python -m inference_server.cli --model_name bigscience/bloom --dtype bf16 --deployment_framework hf_accelerate --generate_kwargs '{"min_length": 100, "max_new_tokens": 100, "do_sample": false}'
+python -m inference_server.cli --model_name bigscience/bloom --model_class AutoModelForCausalLM --dtype bf16 --deployment_framework hf_accelerate --generate_kwargs '{"min_length": 100, "max_new_tokens": 100, "do_sample": false}'
 ```
 
 2. using DS inference
 ```shell
-python -m inference_server.cli --model_name microsoft/bloom-deepspeed-inference-fp16 --dtype fp16 --deployment_framework ds_inference --generate_kwargs '{"min_length": 100, "max_new_tokens": 100, "do_sample": false}'
+python -m inference_server.cli --model_name microsoft/bloom-deepspeed-inference-fp16 --model_class AutoModelForCausalLM --dtype fp16 --deployment_framework ds_inference --generate_kwargs '{"min_length": 100, "max_new_tokens": 100, "do_sample": false}'
 ```
 
 #### BLOOM server deployment
@@ -51,21 +51,21 @@ python -m inference_server.cli --model_name microsoft/bloom-deepspeed-inference-
 
 1. using HF accelerate
 ```shell
-python -m inference_server.benchmark --model_name bigscience/bloom --dtype bf16 --deployment_framework hf_accelerate --benchmark_cycles 5
+python -m inference_server.benchmark --model_name bigscience/bloom --model_class AutoModelForCausalLM --dtype bf16 --deployment_framework hf_accelerate --benchmark_cycles 5
 ```
 
 2. using DS inference
 ```shell
-deepspeed --num_gpus 8 --module inference_server.benchmark --model_name bigscience/bloom --dtype fp16 --deployment_framework ds_inference --benchmark_cycles 5
+deepspeed --num_gpus 8 --module inference_server.benchmark --model_name bigscience/bloom --model_class AutoModelForCausalLM --dtype fp16 --deployment_framework ds_inference --benchmark_cycles 5
 ```
 alternatively, to load model faster:
 ```shell
-deepspeed --num_gpus 8 --module inference_server.benchmark --model_name microsoft/bloom-deepspeed-inference-fp16 --dtype fp16 --deployment_framework ds_inference --benchmark_cycles 5
+deepspeed --num_gpus 8 --module inference_server.benchmark --model_name microsoft/bloom-deepspeed-inference-fp16 --model_class AutoModelForCausalLM --dtype fp16 --deployment_framework ds_inference --benchmark_cycles 5
 ```
 
 3. using DS ZeRO
 ```shell
-deepspeed --num_gpus 8 --module inference_server.benchmark --model_name bigscience/bloom --dtype bf16 --deployment_framework ds_zero --benchmark_cycles 5
+deepspeed --num_gpus 8 --module inference_server.benchmark --model_name bigscience/bloom --model_class AutoModelForCausalLM --dtype bf16 --deployment_framework ds_zero --benchmark_cycles 5
 ```
 
 ## Support

--- a/inference_server/model_handler/deployment.py
+++ b/inference_server/model_handler/deployment.py
@@ -87,7 +87,7 @@ class ModelDeployment(MIIServerClient):
         if args.deployment_framework in [DS_INFERENCE, DS_ZERO]:
             ports = " ".join(map(str, self.ports))
 
-            cmd = f"inference_server.model_handler.launch --model_name {args.model_name} --deployment_framework {args.deployment_framework} --dtype {get_str_dtype(args.dtype)} --port {ports}"
+            cmd = f"inference_server.model_handler.launch --model_name {args.model_name} --deployment_framework {args.deployment_framework} --dtype {get_str_dtype(args.dtype)} --port {ports} --model_class {args.model_class}"
 
             if args.max_batch_size is not None:
                 cmd += f" --max_batch_size {args.max_batch_size}"


### PR DESCRIPTION
Argument model_class has been introduced in https://github.com/huggingface/transformers-bloom-inference/pull/29.
However, it has not been reflected to [deployment code](https://github.com/huggingface/transformers-bloom-inference/blob/dffb799f9d00f8b3228dfdfe7b88727a55b889c6/inference_server/model_handler/deployment.py#L90) as documented in #33.

This fixes #33.