### PR TITLE
fix runtime error with one gpu

### DIFF
--- a/bloom-inference-scripts/bloom-accelerate-inference.py
+++ b/bloom-inference-scripts/bloom-accelerate-inference.py
@@ -57,7 +57,7 @@ if infer_dtype == "int8":
     dtype = torch.int8
 
 kwargs = dict(
-    device_map="balanced_low_0",
+    device_map="auto",
 )
 
 if infer_dtype == "int8":

--- a/bloom-inference-scripts/bloom-accelerate-inference.py
+++ b/bloom-inference-scripts/bloom-accelerate-inference.py
@@ -5,6 +5,7 @@ import os
 import time
 
 import torch
+import torch.distributed as dist
 
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
@@ -59,6 +60,17 @@ if infer_dtype == "int8":
 kwargs = dict(
     device_map="auto",
 )
+
+def get_world_size() -> int:
+    if dist.is_initialized():
+        return dist.get_world_size()
+    else:
+        return 1
+
+# balanced_low_0 - because it allows a larger batch size with multiple GPUs
+if get_world_size() > 1:
+    kwargs["device_map"] = "balanced_low_0"
+
 
 if infer_dtype == "int8":
     print_rank0("Using `load_in_8bit=True` to use quanitized model")


### PR DESCRIPTION
Fixes error with one gpu(RTX3090):
  File "/home/stoyan/workspace/transformers-bloom-inference/.conda/lib/python3.11/site-packages/accelerate/utils/modeling.py", line 419, in get_balanced_memory
    per_gpu = module_sizes[""] // (num_devices - 1 if low_zero else num_devices)
              ~~~~~~~~~~~~~~~~~^^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ZeroDivisionError: integer division or modulo by zero