### PR TITLE
fix checkpoints file list to align with DeepSpeed

### DIFF
--- a/inference_server/models/ds_inference.py
+++ b/inference_server/models/ds_inference.py
@@ -77,7 +77,7 @@ class TemporaryCheckpointsJSON:
     def write_checkpoints_json(self) -> None:
         print(self.model_path)
         with io.open(self.tmp_file, "w", encoding="utf-8") as f:
-            data = {"type": "BLOOM", "checkpoints": glob.glob(f"{self.model_path}/*.bin"), "version": 1.0}
+            data = {"type": "BLOOM", "checkpoints": glob.glob("*.bin", root_dir=self.model_path), "version": 1.0}
             json.dump(data, f)
 
     def __enter__(self):


### PR DESCRIPTION
When use `glob.glob(f"{self.model_path}/*.bin")`, files path in the list will all contain `model_path` prefix. While set it as `root_dir` will not. And it will align to DeepSpeed's loading way ([replace_module.py](https://github.com/microsoft/DeepSpeed/blob/090d49e79fef300046ec0ca22dc3e1bffde74ee1/deepspeed/module_inject/replace_module.py#L567)):
```
sd = [
                    torch.load(os.path.join(base_dir1,
                                            checkpoint[i]),
                               map_location='cpu')
        ]
```
Where `base_dir1` is duplicate with `model_path`.

plz help review @mayank31398, thx~